### PR TITLE
Fix unbounded memory allocation bug

### DIFF
--- a/contentstream/encoding.go
+++ b/contentstream/encoding.go
@@ -68,13 +68,13 @@ func newEncoderFromInlineImage(inlineImage *ContentStreamInlineImage) (core.Stre
 		return newFlateEncoderFromInlineImage(inlineImage, nil)
 	case "LZW", "LZWDecode":
 		return newLZWEncoderFromInlineImage(inlineImage, nil)
-	case "CCF", "CCITTFaxDecode":
-		return core.NewCCITTFaxEncoder(), nil
+	// case "CCF", "CCITTFaxDecode":
+	// 	return core.NewCCITTFaxEncoder(), nil
 	case "RL", "RunLengthDecode":
 		return core.NewRunLengthEncoder(), nil
 	default:
 		common.Log.Debug("Unsupported inline image encoding filter name : %s", *filterName)
-		return nil, errors.New("unsupported inline encoding method")
+		return nil, fmt.Errorf("unsupported inline encoding method (%s)", *filterName)
 	}
 }
 

--- a/core/encoding.go
+++ b/core/encoding.go
@@ -2154,7 +2154,7 @@ func newMultiEncoderFromStream(streamObj *PdfObjectStream) (*MultiEncoder, error
 			mencoder.AddEncoder(encoder)
 		} else {
 			common.Log.Error("Unsupported filter %s", *name)
-			return nil, fmt.Errorf("invalid filter in multi filter array")
+			return nil, fmt.Errorf("invalid filter in multi filter array: %s", *name)
 		}
 	}
 

--- a/core/stream.go
+++ b/core/stream.go
@@ -68,8 +68,8 @@ func NewEncoderFromStream(streamObj *PdfObjectStream) (StreamEncoder, error) {
 		return NewASCIIHexEncoder(), nil
 	case StreamEncodingFilterNameASCII85, "A85":
 		return NewASCII85Encoder(), nil
-	case StreamEncodingFilterNameCCITTFax:
-		return newCCITTFaxEncoderFromStream(streamObj, nil)
+	// case StreamEncodingFilterNameCCITTFax:
+	// 	return newCCITTFaxEncoderFromStream(streamObj, nil)
 	case StreamEncodingFilterNameJBIG2:
 		return newJBIG2DecoderFromStream(streamObj, nil)
 	case StreamEncodingFilterNameJPX:


### PR DESCRIPTION
CCITTFaxDecoder is not safe. Remove CCITTFaxEncoding support from content stream (just like we don't have it in the core module).