### PR TITLE
Add Transform matrix to ImageMark

### DIFF
--- a/extractor/image.go
+++ b/extractor/image.go
@@ -9,7 +9,6 @@ import (
 	"github.com/unidoc/unipdf/v3/common"
 	"github.com/unidoc/unipdf/v3/contentstream"
 	"github.com/unidoc/unipdf/v3/core"
-	"github.com/unidoc/unipdf/v3/internal/transform"
 	"github.com/unidoc/unipdf/v3/model"
 )
 
@@ -61,7 +60,7 @@ type ImageMark struct {
 	// Angle in degrees, if rotated.
 	Angle float64
 
-	Transform transform.Matrix
+	Transform [9]float64
 }
 
 // Provide context for image extraction content stream processing.

--- a/extractor/image.go
+++ b/extractor/image.go
@@ -9,6 +9,7 @@ import (
 	"github.com/unidoc/unipdf/v3/common"
 	"github.com/unidoc/unipdf/v3/contentstream"
 	"github.com/unidoc/unipdf/v3/core"
+	"github.com/unidoc/unipdf/v3/internal/transform"
 	"github.com/unidoc/unipdf/v3/model"
 )
 
@@ -59,6 +60,8 @@ type ImageMark struct {
 
 	// Angle in degrees, if rotated.
 	Angle float64
+
+	Transform transform.Matrix
 }
 
 // Provide context for image extraction content stream processing.
@@ -159,10 +162,11 @@ func (ctx *imageExtractContext) extractInlineImage(iimg *contentstream.ContentSt
 	}
 
 	imgMark := ImageMark{
-		Image:  &rgbImg,
-		Width:  gs.CTM.ScalingFactorX(),
-		Height: gs.CTM.ScalingFactorY(),
-		Angle:  gs.CTM.Angle(),
+		Image:     &rgbImg,
+		Width:     gs.CTM.ScalingFactorX(),
+		Height:    gs.CTM.ScalingFactorY(),
+		Angle:     gs.CTM.Angle(),
+		Transform: gs.CTM,
 	}
 	imgMark.X, imgMark.Y = gs.CTM.Translation()
 
@@ -209,10 +213,11 @@ func (ctx *imageExtractContext) extractXObjectImage(name *core.PdfObjectName, gs
 
 	common.Log.Debug("@Do CTM: %s", gs.CTM.String())
 	imgMark := ImageMark{
-		Image:  &rgbImg,
-		Width:  gs.CTM.ScalingFactorX(),
-		Height: gs.CTM.ScalingFactorY(),
-		Angle:  gs.CTM.Angle(),
+		Image:     &rgbImg,
+		Width:     gs.CTM.ScalingFactorX(),
+		Height:    gs.CTM.ScalingFactorY(),
+		Angle:     gs.CTM.Angle(),
+		Transform: gs.CTM,
 	}
 	imgMark.X, imgMark.Y = gs.CTM.Translation()
 


### PR DESCRIPTION
 - Adds 9 element transform matrix to `ImageMark`
 - This data is part of the `internal` package, but it's useful to include